### PR TITLE
Caffe benchmarking fails on Android #10

### DIFF
--- a/package/lib-caffe-bvlc-master-cpu-android/.cm/meta.json
+++ b/package/lib-caffe-bvlc-master-cpu-android/.cm/meta.json
@@ -68,7 +68,7 @@
       "name": "ProtoBuf library",
       "skip_default": "yes",
       "sort": 16,
-      "tags": "lib,protobuf,v3.0.0"
+      "tags": "lib,protobuf"
     },
     "lib-protobuf-host": {
       "force_target_as_host": "yes",
@@ -76,7 +76,7 @@
       "name": "ProtoBuf host compiler",
       "skip_default": "yes",
       "sort": 19,
-      "tags": "lib,protobuf-host,v3.0.0"
+      "tags": "lib,protobuf-host"
     }
   },
   "end_full_path": {

--- a/program/caffe-time-android/.cm/meta.json
+++ b/program/caffe-time-android/.cm/meta.json
@@ -66,7 +66,7 @@
       "name": "ProtoBuf library", 
       "skip_default": "yes", 
       "sort": 9, 
-      "tags": "lib,protobuf,v3.0.0"
+      "tags": "lib,protobuf"
     }, 
     "xopenme": {
       "local": "yes", 
@@ -112,7 +112,7 @@
           "data_uoa": "569404c41618603a", 
           "script_name": "preprocess"
         },
-        "run_cmd_main": "$#BIN_FILE#$ $<<CK_CAFFE_MODEL_FILE>>$ $<<CK_CAFFE_ITERATIONS>>$",
+        "run_cmd_main": "$#BIN_FILE#$ deploy.prototxt $<<CK_CAFFE_ITERATIONS>>$",
         "run_cmd_out1": "tmp-output1.tmp", 
         "run_cmd_out2": "tmp-output2.tmp", 
         "run_correctness_output_files": [], 
@@ -133,8 +133,9 @@
     }
   }, 
   "run_vars": {
-    "XCT_REPEAT_MAIN": "1"
-  }, 
+    "XCT_REPEAT_MAIN": "1",
+    "CK_CAFFE_ITERATIONS":"2"
+  },
   "skip_bin_ext": "yes", 
   "source_files": [
     "caffe-time.cpp"

--- a/program/caffe-time/.cm/meta.json
+++ b/program/caffe-time/.cm/meta.json
@@ -132,7 +132,8 @@
     }
   }, 
   "run_vars": {
-    "XCT_REPEAT_MAIN": "1"
+    "XCT_REPEAT_MAIN": "1",
+    "CK_CAFFE_ITERATIONS":"2"
   }, 
   "skip_bin_ext": "yes", 
   "source_files": [


### PR DESCRIPTION
- add xopenme timers and handling
- remove hardcoded iterations
- add ability to select proto version (3.1.0 is works fine for android now)