### PR TITLE
Caffe benchmarking fails on Android #10

### DIFF
--- a/program/caffe-time/.cm/meta.json
+++ b/program/caffe-time/.cm/meta.json
@@ -126,6 +126,8 @@
     }
   }, 
   "run_vars": {
+     "XCT_REPEAT_MAIN": "1",
+     "CK_CAFFE_ITERATIONS":"2"
   }, 
   "skip_bin_ext": "yes", 
   "source_files": [


### PR DESCRIPTION
* merge new changes
* add xopenme timers and handling
* remove hardcoded iterations
* add ability to select proto version (3.1.0 is works fine for android now)