### PR TITLE
Compile and run opencl version of caffe for android #22

### DIFF
--- a/program/caffe-opencl-time/caffe.cpp.old
+++ b/program/caffe-opencl-time/caffe.cpp.old
@@ -1,7 +1,11 @@
+
 #ifdef WITH_PYTHON_LAYER
 #include "boost/python.hpp"
 namespace bp = boost::python;
 #endif
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
 
 #include <cstring>
 #include <map>
@@ -10,10 +14,11 @@ namespace bp = boost::python;
 
 #include "boost/algorithm/string.hpp"
 #include "caffe/caffe.hpp"
+#include "caffe/device.hpp"
 #include "caffe/util/signal_handler.h"
 
-#ifdef XOPENME
-#include <xopenme.h>
+#ifdef USE_LIBDNN
+#include "caffe/layers/libdnn_conv_layer.hpp"
 #endif
 
 using caffe::Blob;
@@ -25,16 +30,74 @@ using caffe::shared_ptr;
 using caffe::string;
 using caffe::Timer;
 using caffe::vector;
+using caffe::device;
 using std::ostringstream;
 
-using caffe::device;
+DEFINE_string(gpu, "",
+    "Optional; run in GPU mode on given device IDs separated by ','."
+    "Use '-gpu all' to run on all available GPUs. The effective training "
+    "batch size is multiplied by the number of devices.");
+DEFINE_string(solver, "",
+    "The solver definition protocol buffer text file.");
+DEFINE_string(model, "",
+    "The model definition protocol buffer text file.");
+DEFINE_string(phase, "",
+    "Optional; network phase (TRAIN or TEST). Only used for 'time'.");
+DEFINE_int32(level, 0,
+    "Optional; network level.");
+DEFINE_string(stage, "",
+    "Optional; network stages (not to be confused with phase), "
+    "separated by ','.");
+DEFINE_string(snapshot, "",
+    "Optional; the snapshot solver state to resume training.");
+DEFINE_string(weights, "",
+    "Optional; the pretrained weights to initialize finetuning, "
+    "separated by ','. Cannot be set simultaneously with snapshot.");
+DEFINE_int32(iterations, 50,
+    "The number of iterations to run.");
+DEFINE_string(sigint_effect, "stop",
+             "Optional; action to take when a SIGINT signal is received: "
+              "snapshot, stop or none.");
+DEFINE_string(sighup_effect, "snapshot",
+             "Optional; action to take when a SIGHUP signal is received: "
+             "snapshot, stop or none.");
+
+// A simple registry for caffe commands.
+typedef int (*BrewFunction)();
+typedef std::map<caffe::string, BrewFunction> BrewMap;
+BrewMap g_brew_map;
+
+#define RegisterBrewFunction(func) \
+namespace { \
+class __Registerer_##func { \
+ public: /* NOLINT */ \
+  __Registerer_##func() { \
+    g_brew_map[#func] = &func; \
+  } \
+}; \
+__Registerer_##func g_registerer_##func; \
+}
+
+static BrewFunction GetBrewFunction(const caffe::string& name) {
+  if (g_brew_map.count(name)) {
+    return g_brew_map[name];
+  } else {
+    LOG(ERROR) << "Available caffe actions:";
+    for (BrewMap::iterator it = g_brew_map.begin();
+         it != g_brew_map.end(); ++it) {
+      LOG(ERROR) << "\t" << it->first;
+    }
+    LOG(FATAL) << "Unknown action: " << name;
+    return NULL;  // not reachable, just to suppress old compiler warnings.
+  }
+}
 
 // Parse GPU ids or use all available devices
-static void get_gpus(vector<int>* gpus, string FLAGS_gpu) {
+static void get_gpus(vector<int>* gpus) {
   if (FLAGS_gpu == "all") {
     int count = 0;
 #ifndef CPU_ONLY
-    CUDA_CHECK(cudaGetDeviceCount(&count));
+    count = Caffe::EnumerateDevices(true);
 #else
     NO_GPU;
 #endif
@@ -52,24 +115,60 @@ static void get_gpus(vector<int>* gpus, string FLAGS_gpu) {
   }
 }
 
+// Parse phase from flags
+caffe::Phase get_phase_from_flags(caffe::Phase default_value) {
+  if (FLAGS_phase == "")
+    return default_value;
+  if (FLAGS_phase == "TRAIN")
+    return caffe::TRAIN;
+  if (FLAGS_phase == "TEST")
+    return caffe::TEST;
+  LOG(FATAL) << "phase must be \"TRAIN\" or \"TEST\"";
+  return caffe::TRAIN;  // Avoid warning
+}
+
 // Parse stages from flags
-vector<string> get_stages_from_flags(string FLAGS_stage) {
+vector<string> get_stages_from_flags() {
   vector<string> stages;
   boost::split(stages, FLAGS_stage, boost::is_any_of(","));
   return stages;
 }
 
-// Device Query: show diagnostic information for a GPU device.
-int device_query(string FLAGS_gpu) {
-  LOG(INFO) << "Querying GPUs " << FLAGS_gpu;
-  vector<int> gpus;
-  get_gpus(&gpus, FLAGS_gpu);
-  for (int i = 0; i < gpus.size(); ++i) {
-    caffe::Caffe::SetDevice(gpus[i]);
-    caffe::Caffe::DeviceQuery();
+// caffe commands to call by
+//     caffe <command> <args>
+//
+// To add a command, define a function "int command()" and register it with
+// RegisterBrewFunction(action);
+
+// Device Query: show diagnostic information for a GPU device, or
+// enumerate all devices if none is specified.
+int device_query() {
+  if (FLAGS_gpu.size() == 0 || FLAGS_gpu == "all") {
+    // If no gpu is specified, enumerate all the devices.
+    caffe::Caffe::EnumerateDevices();
+  } else {
+#ifndef CPU_ONLY
+    LOG(INFO) << "Querying GPUs " << FLAGS_gpu;
+    vector<int> gpus;
+    get_gpus(&gpus);
+    Caffe::SetDevices(gpus);
+    for (int i = 0; i < gpus.size(); ++i) {
+      caffe::Caffe::SetDevice(gpus[i]);
+      caffe::Caffe::DeviceQuery();
+    }
+#ifdef USE_GREENTEA
+  if (Caffe::GetDefaultDevice()->backend() == caffe::BACKEND_OpenCL) {
+    if (gpus.size() > 0 && gpus[0] >= 0) {
+      // Explicitly call for OCL + FFT
+      caffe::Caffe::TeardownDevice(gpus[0]);
+    }
+  }
+#endif  // USE_GREENTEA
+#endif  // !CPU_ONLY
   }
   return 0;
 }
+RegisterBrewFunction(device_query);
 
 // Load the weights from the specified caffemodel(s) into the train and
 // test nets.
@@ -102,12 +201,12 @@ caffe::SolverAction::Enum GetRequestedAction(
 }
 
 // Train / Finetune a model.
-int train(string FLAGS_solver, string FLAGS_snapshot, string FLAGS_weights, string FLAGS_stage, int FLAGS_level, string FLAGS_sigint_effect, string  FLAGS_sighup_effect, string FLAGS_gpu) {
+int train() {
   CHECK_GT(FLAGS_solver.size(), 0) << "Need a solver definition to train.";
   CHECK(!FLAGS_snapshot.size() || !FLAGS_weights.size())
       << "Give a snapshot to resume training or weights to finetune "
       "but not both.";
-  vector<string> stages = get_stages_from_flags(FLAGS_stage);
+  vector<string> stages = get_stages_from_flags();
 
   caffe::SolverParameter solver_param;
   caffe::ReadSolverParamsFromTextFileOrDie(FLAGS_solver, &solver_param);
@@ -130,7 +229,7 @@ int train(string FLAGS_solver, string FLAGS_snapshot, string FLAGS_weights, stri
   }
 
   vector<int> gpus;
-  get_gpus(&gpus, FLAGS_gpu);
+  get_gpus(&gpus);
   if (gpus.size() == 0) {
     LOG(INFO) << "Use CPU.";
     Caffe::set_mode(Caffe::CPU);
@@ -191,16 +290,18 @@ int train(string FLAGS_solver, string FLAGS_snapshot, string FLAGS_weights, stri
 #endif
   return 0;
 }
+RegisterBrewFunction(train);
+
 
 // Test: score a model.
-int test(string FLAGS_model, string FLAGS_weights, int FLAGS_level, string FLAGS_stage, int FLAGS_iterations, string FLAGS_gpu) {
+int test() {
   CHECK_GT(FLAGS_model.size(), 0) << "Need a model definition to score.";
   CHECK_GT(FLAGS_weights.size(), 0) << "Need model weights to score.";
-  vector<string> stages = get_stages_from_flags(FLAGS_stage);
+  vector<string> stages = get_stages_from_flags();
 
   // Set device id and mode
   vector<int> gpus;
-  get_gpus(&gpus, FLAGS_gpu);
+  get_gpus(&gpus);
   if (gpus.size() != 0) {
 #ifndef CPU_ONLY
     LOG(INFO) << "Use GPU with device ID " << gpus[0];
@@ -269,47 +370,43 @@ int test(string FLAGS_model, string FLAGS_weights, int FLAGS_level, string FLAGS
 
   return 0;
 }
+RegisterBrewFunction(test);
+
 
 // Time: benchmark the execution time of a model.
-int time(string FLAGS_stage, string FLAGS_model, string FLAGS_weights, int FLAGS_level, int FLAGS_iterations, string FLAGS_gpu) {
+int time() {
   CHECK_GT(FLAGS_model.size(), 0) << "Need a model definition to time.";
-
-  const bool skip_fw = getenv("CK_CAFFE_SKIP_FORWARD")  ? true : false;
-  const bool skip_bw = getenv("CK_CAFFE_SKIP_BACKWARD") ? true : false;
-
-//  caffe::Phase phase = get_phase_from_flags(caffe::TRAIN); todo will fix later based on command line options
-  caffe::Phase phase = caffe::TRAIN;
-  vector<string> stages = get_stages_from_flags(FLAGS_stage);
+  caffe::Phase phase = get_phase_from_flags(caffe::TRAIN);
+  vector<string> stages = get_stages_from_flags();
 
   // Set device id and mode
   vector<int> gpus;
-  get_gpus(&gpus, FLAGS_gpu);
+  get_gpus(&gpus);
   if (gpus.size() != 0) {
+#ifndef CPU_ONLY
     LOG(INFO) << "Use GPU with device ID " << gpus[0];
-    Caffe::SetDevice(gpus[0]);
+    Caffe::SetDevices(gpus);
     Caffe::set_mode(Caffe::GPU);
+    Caffe::SetDevice(gpus[0]);
+#endif  // !CPU_ONLY
   } else {
     LOG(INFO) << "Use CPU.";
     Caffe::set_mode(Caffe::CPU);
   }
-    // Instantiate the caffe net.
+  // Instantiate the caffe net.
   Net<float> caffe_net(FLAGS_model, phase,
-                         Caffe::GetDefaultDevice(), FLAGS_level, &stages);
+                       Caffe::GetDefaultDevice(), FLAGS_level, &stages);
 
   // Do a clean forward and backward pass, so that memory allocation are done
   // and future iterations will be more stable.
+  LOG(INFO) << "Performing Forward";
   // Note that for the speed benchmark, we will assume that the network does
   // not take any input blobs.
-  float initial_loss = 0.0f;
-  if (!skip_fw) {
-    LOG(INFO) << "Performing Forward";
-    caffe_net.Forward(&initial_loss);
-  }
+  float initial_loss;
+  caffe_net.Forward(&initial_loss);
   LOG(INFO) << "Initial loss: " << initial_loss;
-  if (!skip_bw) {
-    LOG(INFO) << "Performing Backward";
-    caffe_net.Backward();
-  }
+  LOG(INFO) << "Performing Backward";
+  caffe_net.Backward();
 
   const vector<shared_ptr<Layer<float> > >& layers = caffe_net.layers();
   const vector<vector<Blob<float>*> >& bottom_vecs = caffe_net.bottom_vecs();
@@ -323,45 +420,35 @@ int time(string FLAGS_stage, string FLAGS_model, string FLAGS_weights, int FLAGS
   Timer forward_timer;
   Timer backward_timer;
   Timer timer;
-
-  #ifdef XOPENME
-    xopenme_clock_start(0);
-  #endif
-
   std::vector<double> forward_time_per_layer(layers.size(), 0.0);
   std::vector<double> backward_time_per_layer(layers.size(), 0.0);
   double forward_time = 0.0;
   double backward_time = 0.0;
-  for (int j = 0; j < FLAGS_iterations; ++j) {
+  for (int_tp j = 0; j < FLAGS_iterations; ++j) {
     Timer iter_timer;
     iter_timer.Start();
-
-    if (!skip_fw) {
-      forward_timer.Start();
-      for (int i = 0; i < layers.size(); ++i) {
-        timer.Start();
-        layers[i]->Forward(bottom_vecs[i], top_vecs[i]);
-        forward_time_per_layer[i] += timer.MicroSeconds();
-       }
-       forward_time += forward_timer.MicroSeconds();
+    forward_timer.Start();
+    for (int_tp i = 0; i < layers.size(); ++i) {
+      timer.Start();
+      layers[i]->Forward(bottom_vecs[i], top_vecs[i]);
+      Caffe::Synchronize(Caffe::GetDefaultDevice()->id());
+      forward_time_per_layer[i] += timer.MicroSeconds();
     }
-
-    if (!skip_bw) {
-      backward_timer.Start();
-      for (int i = layers.size() - 1; i >= 0; --i) {
-        timer.Start();
-        layers[i]->Backward(top_vecs[i], bottom_need_backward[i],
-                            bottom_vecs[i]);
-        backward_time_per_layer[i] += timer.MicroSeconds();
-      }
-      backward_time += backward_timer.MicroSeconds();
+    forward_time += forward_timer.MicroSeconds();
+    backward_timer.Start();
+    for (int_tp i = layers.size() - 1; i >= 0; --i) {
+      timer.Start();
+      layers[i]->Backward(top_vecs[i], bottom_need_backward[i],
+                          bottom_vecs[i]);
+      Caffe::Synchronize(Caffe::GetDefaultDevice()->id());
+      backward_time_per_layer[i] += timer.MicroSeconds();
     }
-
+    backward_time += backward_timer.MicroSeconds();
     LOG(INFO) << "Iteration: " << j + 1 << " forward-backward time: "
       << iter_timer.MilliSeconds() << " ms.";
   }
   LOG(INFO) << "Average time per layer: ";
-  for (int i = 0; i < layers.size(); ++i) {
+  for (int_tp i = 0; i < layers.size(); ++i) {
     const caffe::string& layername = layers[i]->layer_param().name();
     LOG(INFO) << std::setfill(' ') << std::setw(10) << layername <<
       "\tforward: " << forward_time_per_layer[i] / 1000 /
@@ -380,141 +467,100 @@ int time(string FLAGS_stage, string FLAGS_model, string FLAGS_weights, int FLAGS
   LOG(INFO) << "Total Time: " << total_timer.MilliSeconds() << " ms.";
   LOG(INFO) << "*** Benchmark ends ***";
 
-  #ifdef XOPENME
-    xopenme_clock_end(0);
-  #endif
-
+#ifdef USE_GREENTEA
+  if (Caffe::GetDefaultDevice()->backend() == caffe::BACKEND_OpenCL) {
+    if (gpus.size() > 0 && gpus[0] >= 0) {
+      // Explicitly call for OCL + FFT
+      caffe::Caffe::TeardownDevice(gpus[0]);
+    }
+  }
+#endif
   return 0;
 }
+RegisterBrewFunction(time);
 
-const string _gpu = "--gpu=";
-const string _iterations = "--iterations=";
-const string _level = "--level=";
-const string _model = "--model=";
-const string _phase = "--phase=";
-const string _sighup_effect = "--sighup_effect=";
-const string _sigint_effect = "--sigint_effect=";
-const string _snapshot  = "--snapshot=";
-const string _solver  = "--solver=";
-const string _stage  = "--stage=";
-const string _weights  = "--weights=";
 
-const int arg_num = 11;
-const string arguments[arg_num]  = {_gpu, _iterations, _level, _model, _phase, _sighup_effect, _sigint_effect, _snapshot, _solver, _stage, _weights};
+int autotune() {
+  CHECK_GT(FLAGS_model.size(), 0) << "Need a model definition to time.";
 
-string getArgumentValue(int argc, char** argv, string param_key) {
-  for (int argi = 2; argi < argc; argi ++) {
-      string param = argv[argi];
-      std::size_t found = param.find(param_key);
-      if (found!=std::string::npos) {
-        string param_value = param.substr(param_key.length(),param.length() - 1);
-        LOG(INFO) << "found param key: " << param_key;
-        LOG(INFO) << "found param value: " << param_value << std::endl;
-        return param_value;
-      }
+  vector<int> gpus;
+  get_gpus(&gpus);
+  if (gpus.size() == 0) {
+    LOG(INFO) << "Use CPU.";
+    Caffe::set_mode(Caffe::CPU);
+  } else {
+#ifndef CPU_ONLY
+    // Load all devices that will be used
+    Caffe::SetDevices(gpus);
+
+    ostringstream s;
+    for (int_tp i = 0; i < gpus.size(); ++i) {
+      s << (i ? ", " : "") << gpus[i];
+    }
+    LOG(INFO) << "Using GPUs " << s.str();
+    // Initialize the first device
+    Caffe::SetDevice(gpus[0]);
+    Caffe::set_mode(Caffe::GPU);
+    Caffe::set_solver_count(gpus.size());
+#endif  // !CPU_ONLY
   }
-  return "";
-}
 
-void printUsage() {
-  std::cerr << "command line brew\n"
-          "usage: caffe <command> <args>\n\n"
-          "commands:\n"
-          "  train           train or finetune a model\n"
-          "  test            score a model\n"
-          "  device_query    show GPU diagnostic information\n"
-          "  time            benchmark model execution time" << std::endl;
+  caffe::SignalHandler signal_handler(
+        GetRequestedAction(FLAGS_sigint_effect),
+        GetRequestedAction(FLAGS_sighup_effect));
 
-  std::cerr << "\nArgs:  \n"
-          "    -gpu (Optional; run in GPU mode on given device IDs separated by ','.Use\n"
-          "      '-gpu all' to run on all available GPUs. The effective training batch\n"
-          "      size is multiplied by the number of devices.) type: string default: \"\"\n"
-          "    -iterations (The number of iterations to run.) type: int32 default: 50\n"
-          "    -level (Optional; network level.) type: int32 default: 0\n"
-          "    -model (The model definition protocol buffer text file.) type: string\n"
-          "      default: \"\"\n"
-          "    -phase (Optional; network phase (TRAIN or TEST). Only used for 'time'.)\n"
-          "      type: string default: \"\"\n"
-          "    -sighup_effect (Optional; action to take when a SIGHUP signal is received:\n"
-          "      snapshot, stop or none.) type: string default: \"snapshot\"\n"
-          "    -sigint_effect (Optional; action to take when a SIGINT signal is received:\n"
-          "      snapshot, stop or none.) type: string default: \"stop\"\n"
-          "    -snapshot (Optional; the snapshot solver state to resume training.)\n"
-          "      type: string default: \"\"\n"
-          "    -solver (The solver definition protocol buffer text file.) type: string\n"
-          "      default: \"\"\n"
-          "    -stage (Optional; network stages (not to be confused with phase), separated\n"
-          "      by ','.) type: string default: \"\"\n"
-          "    -weights (Optional; the pretrained weights to initialize finetuning,\n"
-          "      separated by ','. Cannot be set simultaneously with snapshot.)\n"
-          "      type: string default: \"\"" << std::endl;
+  Net<float> net(FLAGS_model, caffe::TRAIN, Caffe::GetDefaultDevice());
+
+  for (int i = 0; i < net.layers().size(); ++i) {
+#ifdef USE_LIBDNN
+    shared_ptr<caffe::LibDNNConvolutionLayer<float> > layer =
+        boost::dynamic_pointer_cast<caffe::LibDNNConvolutionLayer<float> >
+                (net.layers()[i]);
+    if (layer.get() != nullptr) {
+      float* top_data = net.top_vecs()[i][0]->mutable_gpu_data();
+      float* top_diff = net.top_vecs()[i][0]->mutable_gpu_diff();
+      float* bottom_data = net.top_vecs()[i][0]->mutable_gpu_data();
+      float* bottom_diff = net.top_vecs()[i][0]->mutable_gpu_diff();
+      int_tp batch_size = net.top_vecs()[i][0]->shape(0);
+      layer->Tune(top_data, top_diff, bottom_data, bottom_diff, batch_size);
+    }
+#endif  // USE_LIBDNN
+  }
+  return 0;
 }
+RegisterBrewFunction(autotune);
+
+
+
 
 int main(int argc, char** argv) {
-  #ifdef XOPENME
-    xopenme_init(1,0);
-  #endif
-
-  if (argc < 2) {
-    printUsage();
-    return 1;
-  }
-
-  string command = argv[1];
-  LOG(INFO) << "Start with command: " << command;
-  if (command == "time") {
-    if (argc < 5) {
-      std::cerr << "invalid argument number for command time" << std::endl;
+  // Print output to stderr (while still logging).
+  FLAGS_alsologtostderr = 1;
+  // Set version
+  gflags::SetVersionString(AS_STRING(CAFFE_VERSION));
+  // Usage message.
+  gflags::SetUsageMessage("command line brew\n"
+      "usage: caffe <command> <args>\n\n"
+      "commands:\n"
+      "  train           train or finetune a model\n"
+      "  test            score a model\n"
+      "  device_query    show GPU diagnostic information\n"
+      "  time            benchmark model execution time"
+      "  autotune        autotune a model");
+  // Run tool or show usage.
+  caffe::GlobalInit(&argc, &argv);
+  if (argc == 2) {
+#ifdef WITH_PYTHON_LAYER
+    try {
+#endif
+      return GetBrewFunction(caffe::string(argv[1]))();
+#ifdef WITH_PYTHON_LAYER
+    } catch (bp::error_already_set) {
+      PyErr_Print();
       return 1;
     }
-    string modelFilePath = getArgumentValue(argc, argv, _model);
-    string weightFilePath = getArgumentValue(argc, argv, _weights);
-    int iterations = atoi(getArgumentValue(argc, argv, _iterations).c_str());
-    int level = atoi(getArgumentValue(argc, argv, _level).c_str());
-    string stages = getArgumentValue(argc, argv, _stage);
-    string gpu = getArgumentValue(argc, argv, _gpu);
-    time(stages, modelFilePath, weightFilePath, level, iterations, gpu);
-  } else if (command == "train") {
-    if (argc < 9) {
-      std::cerr << "invalid argument number for command train" << std::endl;
-      return 1;
-    }
-    string FLAGS_solver = getArgumentValue(argc, argv, _solver);
-    string FLAGS_snapshot = getArgumentValue(argc, argv, _snapshot);
-    string FLAGS_weights = getArgumentValue(argc, argv, _weights);
-    string FLAGS_stage = getArgumentValue(argc, argv, _stage);
-    int FLAGS_level = atoi(getArgumentValue(argc, argv, _level).c_str());
-    string FLAGS_sigint_effect = getArgumentValue(argc, argv, _sigint_effect);
-    string  FLAGS_sighup_effect = getArgumentValue(argc, argv, _sighup_effect);
-    string gpu = getArgumentValue(argc, argv, _gpu);
-    train(FLAGS_solver, FLAGS_snapshot, FLAGS_weights, FLAGS_stage, FLAGS_level, FLAGS_sigint_effect, FLAGS_sighup_effect, gpu);
-  } else if (command == "test") {
-    if (argc < 7) {
-        std::cerr << "invalid argument number for command test" << std::endl;
-        return 1;
-    }
-    string FLAGS_model = getArgumentValue(argc, argv, _model);
-    string FLAGS_weights = getArgumentValue(argc, argv, _weights);
-    int FLAGS_level = atoi(getArgumentValue(argc, argv, _level).c_str());
-    string FLAGS_stage = getArgumentValue(argc, argv, _stage);
-    int FLAGS_iterations = atoi(getArgumentValue(argc, argv, _iterations).c_str());
-    string gpu = getArgumentValue(argc, argv, _gpu);
-    test(FLAGS_model, FLAGS_weights, FLAGS_level, FLAGS_stage, FLAGS_iterations, gpu);
-  } else if (command == "device_query") {
-    if (argc < 3) {
-        std::cerr << "invalid argument number for command device_query" << std::endl;
-        return 1;
-    }
-    string gpu = getArgumentValue(argc, argv, _gpu);
-    device_query(gpu);
+#endif
   } else {
-    std::cerr << "provided command not found\n" << std::endl;
-    printUsage();
-    return 1;
+    gflags::ShowUsageWithFlagsRestrict(argv[0], "tools/caffe");
   }
-
-  #ifdef XOPENME
-   xopenme_dump_state();
-   xopenme_finish();
-  #endif
 }


### PR DESCRIPTION
- I've merged my wraper program without gflags with opencl version of caffe.cpp
  (opencl version uses different caffe API)
  and it works fine now using ck without segfaults and same json timing as well as caffe-time version