### PR TITLE
Enable continuous mode for OpenCL classification

### DIFF
--- a/program/caffe-classification-opencl/.cm/info.json
+++ b/program/caffe-classification-opencl/.cm/info.json
@@ -17,5 +17,5 @@
       "1"
     ]
   },
-  "data_name": "caffe-classification-opencl"
+  "data_name": "Caffe classification via OpenCL"
 }

--- a/program/caffe-classification-opencl/.cm/meta.json
+++ b/program/caffe-classification-opencl/.cm/meta.json
@@ -109,8 +109,8 @@
     "CK_ENV_LIB_CAFFE_EXTRA_INCLUDE"
   ],
   "compiler_env": "CK_CXX",
-  "compiler_flags_as_env": "$<<CK_OPT_UNWIND>>$ $<<CK_ENV_LIB_CAFFE_CXXFLAGS>>$",
-  "data_name": "caffe-classification-opencl",
+  "compiler_flags_as_env": "$<<CK_OPT_UNWIND>>$ $<<CK_ENV_LIB_CAFFE_CXXFLAGS>>$ $<<CK_COMPILER_FLAG_CPP11>>$",
+  "data_name": "Caffe classification via OpenCL",
   "extra_ld_vars": "$<<CK_ENV_LIB_HDF5_LFLAG>>$ $<<CK_ENV_LIB_HDF5_LFLAG_HL>>$ $<<CK_ENV_LIB_GLOG_LFLAG>>$ $<<CK_ENV_LIB_BOOST_LFLAG_THREAD>>$ $<<CK_ENV_LIB_BOOST_LFLAG_DATE_TIME>>$ $<<CK_ENV_LIB_BOOST_LFLAG_FILESYSTEM>>$ $<<CK_ENV_LIB_BOOST_LFLAG_SYSTEM>>$ $<<CK_ENV_LIB_OPENCV_LFLAG_IMGPROC>>$ $<<CK_ENV_LIB_OPENCV_LFLAG_HIGHGUI>>$ $<<CK_ENV_LIB_OPENCV_LFLAG_CORE>>$ $<<CK_ENV_LIB_OPENCV_LFLAG_IMGCODECS>>$ $<<CK_EXTRA_LIB_Z>>$ $<<CK_EXTRA_LIB_LOG>>$ $<<CK_EXTRA_LIB_M>>$  $<<CK_ENV_LIB_CAFFE_LFLAG_PROTO>>$ $<<CK_ENV_LIB_CAFFE_LINK_FLAGS>>$ $<<CK_ENV_LIB_STDCPP_STATIC>>$",
   "main_language": "cpp",
   "only_for_target_os_tags": [
@@ -183,6 +183,48 @@
           "tmp-ck-timer.json"
         ]
       }
+    },
+    "use_continuous": {
+      "ignore_return_code": "no",
+      "run_time": {
+        "fine_grain_timer_file": "tmp-ck-timer.json",
+        "params": {
+          "caffemodel_key": "deploy",
+          "classification": "yes"
+        },
+        "pre_process_via_ck": {
+          "data_uoa": "569404c41618603a",
+          "script_name": "preprocess"
+        },
+        "run_cmd_main": "$#BIN_FILE#$ $<<CK_CAFFE_MODEL_FILE>>$ $<<CK_CAFFE_MODEL_WEIGHTS>>$ $<<CK_CAFFE_IMAGENET_MEAN_BIN>>$ $<<CK_CAFFE_IMAGENET_SYNSET_WORDS_TXT>>$ --continuous $<<CK_CAFFE_IMAGENET_VAL>>$ $<<CK_CAFFE_IMAGENET_VAL_TXT>>$ $<<CAFFE_COMPUTE_DEVICE_ID>>$",
+        "run_cmd_out1": "tmp-output1.tmp",
+        "run_cmd_out2": "tmp-output2.tmp",
+        "run_correctness_output_files": [],
+        "run_input_files": [
+          "$<<CK_CAFFE_MODEL_FILE>>$",
+          "$<<CK_ENV_MODEL_CAFFE_WEIGHTS>>$",
+          "$<<CK_CAFFE_IMAGENET_MEAN_BIN>>$",
+          "$<<CK_CAFFE_IMAGENET_SYNSET_WORDS_TXT>>$"
+        ],
+        "run_output_files": [
+          "tmp-output.tmp",
+          "tmp-ck-timer.json"
+        ]
+      },
+      "run_deps": {
+        "imagenet-aux": {
+          "local": "yes",
+          "name": "ImageNet (aux)",
+          "sort": 50,
+          "tags": "imagenet,aux"
+        },
+        "imagenet-val": {
+          "local": "yes",
+          "name": "ImageNet (val)",
+          "sort": 60,
+          "tags": "imagenet,val"
+        }
+      }
     }
   },
   "run_deps": {
@@ -205,7 +247,8 @@
   "tags": [
     "caffe-classification",
     "demo",
-    "vcuda"
+    "vcuda",
+    "continuous"
   ],
   "target_file": "classification",
   "version": "1.0.0"

--- a/program/caffe-classification-opencl/classification.cpp
+++ b/program/caffe-classification-opencl/classification.cpp
@@ -10,10 +10,17 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <fstream>
+#include <map>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 
 #ifdef XOPENME
 #include <xopenme.h>
 #endif
+
+namespace fs = boost::filesystem;
 
 #ifdef USE_OPENCV
 using namespace caffe;  // NOLINT(build/namespaces)
@@ -23,6 +30,7 @@ using std::string;
 typedef std::pair<string, float> Prediction;
 
 int FLAGS_gpu = 0;
+bool supress_debug_output = false;
 
 class Classifier {
  public:
@@ -32,6 +40,8 @@ class Classifier {
              const string& label_file);
 
   std::vector<Prediction> Classify(const cv::Mat& img, int_tp N = 5);
+
+  std::string GetLabel(int index) { return labels_.size() <= index ? "" : labels_[index]; }
 
  private:
   void SetMean(const string& mean_file);
@@ -78,15 +88,21 @@ Classifier::Classifier(const string& model_file,
 
     if (FLAGS_gpu < 0 || FLAGS_gpu > gpus.size()) {
        std::cerr << "gpu_id value must be positive and less or eq " << gpus.size() - 1 << std::endl;
-       std::cout << "gpu_id value selected to default 0" << std::endl;
+       if (!supress_debug_output) {
+        std::cout << "gpu_id value selected to default 0" << std::endl;
+       }
        FLAGS_gpu = 0;
     }
-    std::cout << "Use GPU with device ID " << gpus[FLAGS_gpu] << std::endl;
+    if (!supress_debug_output) {
+      std::cout << "Use GPU with device ID " << gpus[FLAGS_gpu] << std::endl;
+    }
     Caffe::SetDevice(gpus[FLAGS_gpu]);
 
 #endif  // !CPU_ONLY
   } else {
-    std::cout << "Use CPU" << std::endl;
+    if (!supress_debug_output) {
+      std::cout << "Use CPU" << std::endl;
+    }
     Caffe::set_mode(Caffe::CPU);
   }
 
@@ -262,77 +278,157 @@ void Classifier::Preprocess(const cv::Mat& img,
     << "Input channels are not wrapping the input layer of the network.";
 }
 
-int main(int argc, char** argv) {
+void x_clock_start(int timer) {
+#ifdef XOPENME
+  xopenme_clock_start(timer);
+#endif
+}
 
+void x_clock_end(int timer) {
+#ifdef XOPENME
+  xopenme_clock_end(timer);
+#endif
+}
+
+double x_get_time(int timer) {
+#ifdef XOPENME
+  return xopenme_get_timer(timer);
+#else
+  return 0;
+#endif
+}
+
+void classify_single_image(Classifier& classifier, const fs::path& file_path) {
   long ct_repeat=0;
   long ct_repeat_max=1;
   int ct_return=0;
 
+  if (getenv("CT_REPEAT_MAIN")!=NULL) ct_repeat_max=atol(getenv("CT_REPEAT_MAIN"));
+
+  string file = file_path.string();
+
+  std::cout << "---------- Prediction for " << file << " ----------" << std::endl;
+
+  x_clock_start(1);
+  cv::Mat img = cv::imread(file, -1);
+  x_clock_end(1);
+  CHECK(!img.empty()) << "Unable to decode image " << file;
+
+  x_clock_start(2);
+
+  std::vector<Prediction> predictions;
+
+  for (ct_repeat=0; ct_repeat<ct_repeat_max; ct_repeat++) {
+    predictions = classifier.Classify(img);
+  }
+
+  x_clock_end(2);
+
+  /* Print the top N predictions. */
+  for (size_t i = 0; i < predictions.size(); ++i) {
+    Prediction p = predictions[i];
+    std::cout << std::fixed << std::setprecision(4) << p.second << " - \"" << p.first << "\"" << std::endl;
+  }
+}
+
+void classify_continuously(Classifier& classifier, const fs::path& val_path, const fs::path& dir) {
+  std::map<std::string, std::string> correct_labels;
+
+  std::ifstream val_file(val_path.string());
+  while (!val_file.eof()) {
+    std::string fname = "";
+    int index = 0;
+    val_file >> fname >> index;
+    if (fname != "") {
+      std::string label = classifier.GetLabel(index);
+      if (label != "") {
+        correct_labels[boost::to_upper_copy(fname)] = label;
+      }
+    }
+  }
+
+  const int timer = 2;
+  fs::directory_iterator end_iter;
+  while (true) {
+    for (fs::directory_iterator dir_iter(dir) ; dir_iter != end_iter ; ++dir_iter){
+      if (!fs::is_regular_file(dir_iter->status())) {
+        // skip non-images
+        continue;
+      }
+      string file = dir_iter->path().string();
+      cv::Mat img = cv::imread(file, -1);
+      if (img.empty()) {
+        // TODO: should we complain?
+        continue;
+      }
+      std::vector<Prediction> predictions;
+      x_clock_start(timer);
+      predictions = classifier.Classify(img);
+      x_clock_end(timer);
+      std::cout << "File: " << file << std::endl;
+      std::cout << "Duration: " << x_get_time(timer) << " sec" << std::endl;
+      auto correct_iter = correct_labels.find(boost::to_upper_copy(dir_iter->path().filename().string()));
+      std::string label = "";
+      if (correct_iter != correct_labels.end()) {
+        label = correct_iter->second;
+      }
+      std::cout << "Correct label: " << label << std::endl;
+      std::cout << "Predictions: " << predictions.size() << std::endl;
+      for (size_t i = 0; i < predictions.size(); ++i) {
+        Prediction p = predictions[i];
+        std::cout << std::fixed << std::setprecision(4) << p.second << " - \"" << p.first << "\"" << std::endl;
+      }
+      std::cout << std::endl;
+      std::cout.flush();
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+
 #ifdef XOPENME
   xopenme_init(3,0);
 #endif
-  if (getenv("CT_REPEAT_MAIN")!=NULL) ct_repeat_max=atol(getenv("CT_REPEAT_MAIN"));
-
 
   if (argc < 6) {
     std::cerr << "Usage: " << argv[0]
               << " deploy.prototxt network.caffemodel"
-              << " mean.binaryproto labels.txt img.jpg [gpu_id]" << std::endl;
+              << " mean.binaryproto labels.txt <img.jpg | --continuous directory-with-images val.txt> [gpu_id]" << std::endl;
     return 1;
   }
 
   ::google::InitGoogleLogging(argv[0]);
+
+  bool continuous_mode = argc >= 8 && string(argv[5]) == "--continuous";
+  if (continuous_mode) {
+    supress_debug_output = true;
+  }
 
   string model_file   = argv[1];
   string trained_file = argv[2];
   string mean_file    = argv[3];
   string label_file   = argv[4];
 
-#ifdef XOPENME
-  xopenme_clock_start(0);
-#endif
-
-  if (argc == 7) {
-    FLAGS_gpu = atoi(argv[6]);
+  if ((continuous_mode && argc == 9) || (!continuous_mode && argc == 7)) {
+    FLAGS_gpu = atoi(argv[continuous_mode ? 8 : 6]);
   }
 
+  x_clock_start(0);
   Classifier classifier(model_file, trained_file, mean_file, label_file);
-#ifdef XOPENME
-  xopenme_clock_end(0);
-#endif
+  x_clock_end(0);
 
-  string file = argv[5];
+  if (continuous_mode) {
+    fs::path path(argv[6]);
+    CHECK(fs::exists(path)) << "Path to the directory with images doesn't exist " << path;
 
-  std::cout << "---------- Prediction for "
-            << file << " ----------" << std::endl;
+    fs::path val_path(argv[7]);
+    CHECK(fs::exists(val_path)) << "Val file doesn't exist " << val_path;
 
-#ifdef XOPENME
-  xopenme_clock_start(1);
-#endif
-  cv::Mat img = cv::imread(file, -1);
-#ifdef XOPENME
-  xopenme_clock_end(1);
-#endif
-  CHECK(!img.empty()) << "Unable to decode image " << file;
-
-#ifdef XOPENME
-  xopenme_clock_start(2);
-#endif
-
-  std::vector<Prediction> predictions;
-
-  for (ct_repeat=0; ct_repeat<ct_repeat_max; ct_repeat++)
-    predictions = classifier.Classify(img);
-
-#ifdef XOPENME
-  xopenme_clock_end(2);
-#endif
-
-  /* Print the top N predictions. */
-  for (size_t i = 0; i < predictions.size(); ++i) {
-    Prediction p = predictions[i];
-    std::cout << std::fixed << std::setprecision(4) << p.second << " - \""
-              << p.first << "\"" << std::endl;
+    classify_continuously(classifier, val_path, path);
+  } else {
+    fs::path path(argv[5]);
+    CHECK(fs::exists(path)) << "Path doesn't exist " << path;
+    classify_single_image(classifier, path);
   }
 
 #ifdef XOPENME
@@ -340,6 +436,7 @@ int main(int argc, char** argv) {
   xopenme_finish();
 #endif
 
+  return 0;
 }
 #else
 int main(int argc, char** argv) {


### PR DESCRIPTION
Hi,

This PR enables continuous mode for `caffe-classification-opencl`. Majority of the code is just copy-pasted from `caffe-classification`, so the PR is pretty straightforward. 