### PR TITLE
Add aux_uoa field for the imagenet VAL packages metas

### DIFF
--- a/package/imagenet-2012-val-lmdb-256/.cm/meta.json
+++ b/package/imagenet-2012-val-lmdb-256/.cm/meta.json
@@ -1,5 +1,6 @@
 {
   "check_exit_status": "yes", 
+  "aux_uoa": "4e3e9dd897f125bb",
   "customize": {
     "force_ask_path": "yes", 
     "install_env": {

--- a/package/imagenet-2012-val-min-resized/.cm/meta.json
+++ b/package/imagenet-2012-val-min-resized/.cm/meta.json
@@ -1,5 +1,6 @@
 {
   "check_exit_status": "yes",
+  "aux_uoa": "4e3e9dd897f125bb",
   "customize": {
     "extra_dir": "",
     "force_ask_path": "yes",

--- a/package/imagenet-2012-val-min/.cm/meta.json
+++ b/package/imagenet-2012-val-min/.cm/meta.json
@@ -1,5 +1,6 @@
 {
   "check_exit_status": "yes",
+  "aux_uoa": "4e3e9dd897f125bb",
   "customize": {
     "extra_dir": "",
     "force_ask_path": "yes",

--- a/package/imagenet-2012-val/.cm/meta.json
+++ b/package/imagenet-2012-val/.cm/meta.json
@@ -1,5 +1,6 @@
 {
   "check_exit_status": "yes",
+  "aux_uoa": "4e3e9dd897f125bb",
   "customize": {
     "extra_dir": "",
     "force_ask_path":"yes",


### PR DESCRIPTION
Hi,

This PR adds `aux_uoa` field to VAL metas. The field point to the corresponding AUX package. This is needed so that third-parties (like the demo app) can understand which AUX to use with this VAL.